### PR TITLE
More locale for Schall Uranium Processing

### DIFF
--- a/locale/de/base.cfg
+++ b/locale/de/base.cfg
@@ -23,7 +23,7 @@ explosive-plutonium-cannon-shell=Plutonium-Sprenggranate
 plutonium-atomic-bomb=Plutoniumbombe
 
 [item-description]
-MOX-fuel=Bietet viel mehr Energie als Uran-Brennstoffzelle, aber bei 50% Leistung.
+MOX-fuel=Biete viel mehr Energie als Uran-Brennstoffzelle, aber bei 50% Leistung.
 used-up-MOX-fuel=Diese Brennstoffzelle hat keine Energie mehr, kann aber zu zusätzlichem Plutonium wiederaufbereitet werden.
 MOX-reactor=Durch die langsamere Stromerzeugung von Plutonium kann der Reaktor kleiner werden.
 industrial-reactor=Chemischen Trennanlage zur Nukleosynthese und Aufbereitung.
@@ -51,7 +51,7 @@ plutonium-processing=Plutoniumverarbeitung
 
 [technology-description]
 plutonium-processing=Verarbeitung von Plutonium, das in der Natur nicht vorkommt, aber im Kernreaktor erzeugt werden kann.
-plutonium-nuclear-power=Bietet viel mehr Energie als Uran, aber bei 50% Leistung.
+plutonium-nuclear-power=Biete viel mehr Energie als Uran, aber bei 50% Leistung.
 MOX-fuel-reprocessing=Der Wiederaufbereitungsprozess verbrauchte MOX-Brennstoff, um zusätzliches Plutonium zu erhalten.
 plutonium-ammo=Fortgeschrittene Munition aus Plutonium, welches zu massiven Schäden führt.
 plutonium-atomic-bomb=Atombombe aus Plutonium statt Uran. Die Sprengkraft ist um fast 40% höher.
@@ -59,10 +59,12 @@ plutonium-atomic-bomb=Atombombe aus Plutonium statt Uran. Die Sprengkraft ist um
 [mod-setting-name]
 PE-disable-MOX-reactor=Rezept des MOX-Kernreaktors deaktivieren
 PE-disable-U238-excess-neutron-capture-recipe=Rezept für Neutroneneinfang von Uran-238 deaktivieren
+PE-SUP-advanced-nfr-uranium-concentrate=Rezept für fortgeschrittene Wiederaufbereitung von Kernbrennstoff ändern
 
 [mod-setting-description]
-PE-disable-MOX-reactor=Deaktivieren Sie den MOX-Kernreaktor, um die Kompatibilität mit einigen Mods zu gewährleisten.
+PE-disable-MOX-reactor=Deaktiviere den MOX-Kernreaktor, um die Kompatibilität mit einigen Mods zu gewährleisten.
+PE-disable-U238-excess-neutron-capture-recipe=Einige Spieler möchten, dass dieses Rezept zum Ausgleichen deaktiviert wird.
+PE-SUP-advanced-nfr-uranium-concentrate=Ersetze Uran-238 (Abgereichertes Uran) durch Urankonzentrat als Produkt im Rezept für fortgeschrittene Wiederaufbereitung von Kernbrennstoff, wenn sowohl diese Option als auch der Mod „Schall Uranium Processing“ aktiviert sind.
 
 [mod-description]
-PlutoniumEnergy=Fügt die Verarbeitung von Plutonium hinzu, einem überschüssigen Produkt aus der Kernreaktion. Plutonium kann zur Herstellung von Munition (auch Plutoniumbombe) und zur Stromerzeugung (als MOX-Brennstoff) verwendet werden.
-PE-disable-U238-excess-neutron-capture-recipe=Einige Spieler möchten, dass dieses Rezept zum Ausgleichen deaktiviert wird.
+PlutoniumEnergy=Füge die Verarbeitung von Plutonium hinzu, einem überschüssigen Produkt aus der Kernreaktion. Plutonium kann zur Herstellung von Munition (auch Plutoniumbombe) und zur Stromerzeugung (als MOX-Brennstoff) verwendet werden.

--- a/locale/zh-CN/base.cfg
+++ b/locale/zh-CN/base.cfg
@@ -59,10 +59,12 @@ plutonium-atomic-bomb=使用钚取代铀制成的原子弹。爆炸威力提高�
 [mod-setting-name]
 PE-disable-MOX-reactor=禁用混合氧化物核反应堆配方
 PE-disable-U238-excess-neutron-capture-recipe=停用铀-238 中子捕获配方
+PE-SUP-advanced-nfr-uranium-concentrate=修改高等乏燃料后处理配方
 
 [mod-setting-description]
 PE-disable-MOX-reactor=为与某些模块兼容而禁用混合氧化物核反应堆。
 PE-disable-U238-excess-neutron-capture-recipe=一些玩家因平衡理由，希望移除这个配方。
+PE-SUP-advanced-nfr-uranium-concentrate=同时启用了此选项和《疾风铀加工》模组时，则高等乏燃料后处理配方中的产品将以铀精矿替代铀-238（贫铀）。
 
 [mod-name]
 PlutoniumEnergy=钚能 (Plutonium Energy)

--- a/locale/zh-CN/base.cfg
+++ b/locale/zh-CN/base.cfg
@@ -64,7 +64,7 @@ PE-SUP-advanced-nfr-uranium-concentrate=修改高等乏燃料后处理配方
 [mod-setting-description]
 PE-disable-MOX-reactor=为与某些模块兼容而禁用混合氧化物核反应堆。
 PE-disable-U238-excess-neutron-capture-recipe=一些玩家因平衡理由，希望移除这个配方。
-PE-SUP-advanced-nfr-uranium-concentrate=同时启用了此选项和《疾风铀加工》模组时，则高等乏燃料后处理配方中的产品将以铀精矿替代铀-238（贫铀）。
+PE-SUP-advanced-nfr-uranium-concentrate=同时启用了此选项和《疾风铀处理》模组时，则高等乏燃料后处理配方中的产品将以铀精矿替代铀-238（贫铀）。
 
 [mod-name]
 PlutoniumEnergy=钚能 (Plutonium Energy)

--- a/locale/zh-TW/base.cfg
+++ b/locale/zh-TW/base.cfg
@@ -59,10 +59,12 @@ plutonium-atomic-bomb=使用鈈取代鈾製成的核彈。爆炸威力提高近�
 [mod-setting-name]
 PE-disable-MOX-reactor=停用混合氧化物核能反應爐配方
 PE-disable-U238-excess-neutron-capture-recipe=停用鈾-238 中子捕獲配方
+PE-SUP-advanced-nfr-uranium-concentrate=修改進階核燃料後加工配方
 
 [mod-setting-description]
 PE-disable-MOX-reactor=為與某些模組兼容而停用混合氧化物核能反應爐。
 PE-disable-U238-excess-neutron-capture-recipe=一些玩家因平衡理由，希望移除這個配方。
+PE-SUP-advanced-nfr-uranium-concentrate=同時啟用了此選項和《疾風鈾加工》模組時，則進階核燃料後加工配方中的產品將以鈾精礦替代鈾-238（貧鈾）。
 
 [mod-name]
 PlutoniumEnergy=鈈能 (Plutonium Energy)


### PR DESCRIPTION
[de] Also some minor wording consistency.
[de] Move "PE-disable-U238-excess-neutron-capture-recipe" back to [mod-setting-description], was wrongly placed in [mod-description],