### PR TITLE
1.1.20

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,11 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.1.20
+Date: 26.08.2020
+  Fixes:
+    - Fixed error on load when Atomic Artillery, PE and Bob's Warfare are enabled
+  Integration:
+    - Plutonium Atomic Artillery shell is now available with Bob's Warfare mod.
+---------------------------------------------------------------------------------------------------
 Version: 1.1.19
 Date: 25.08.2020
   Fixes:

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,12 @@ Date: 26.08.2020
     - Fixed error on load when Atomic Artillery, PE and Bob's Warfare are enabled
   Integration:
     - Plutonium Atomic Artillery shell is now available with Bob's Warfare mod.
+  Balancing:
+    - Plutonium atomic bomb:
+      Removed processing unit from recipe
+      Removed Pu-238 from recipe
+      Pu-239 10x -> 35x
+      Added x10 Rocket control unit
 ---------------------------------------------------------------------------------------------------
 Version: 1.1.19
 Date: 25.08.2020

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "PlutoniumEnergy",
-    "version": "1.1.19",
+    "version": "1.1.20",
     "title": "Plutonium Energy",
     "author": "JohnTheCoolingFan",
     "contact": "https://discord.gg/grHVhE2",

--- a/info.json
+++ b/info.json
@@ -9,7 +9,8 @@
         "base >= 1.0.0",
         "? AtomicArtillery",
         "? SchallUraniumProcessing",
-        "? bobplates"
+        "? bobplates",
+        "? bobwarfare"
     ],
     "description": "Adds processing of plutonium, excess product from nuclear reaction. Plutonium can be used to create ammo (even plutonium atomic bomb) and to create energy as MOX fuel.",
     "factorio_version": "1.0"

--- a/prototypes/entity/projectiles.lua
+++ b/prototypes/entity/projectiles.lua
@@ -61,7 +61,7 @@ if mods['bobwarfare'] then
     plutonium_atomic_artillery_projectile.action.action_delivery.target_effects[6].radius = 10
     plutonium_atomic_artillery_projectile.action.action_delivery.target_effects[7].action.repeat_count = 2800
     plutonium_atomic_artillery_projectile.action.action_delivery.target_effects[7].action.radius = 50
-    plutonium_atomic_artillery_projectile.action.action_delivery.target_effects[7].action.action_delivery.projectile = "plutonium-atomic-artillery-wave"
+    --plutonium_atomic_artillery_projectile.action.action_delivery.target_effects[7].action.action_delivery.projectile = "plutonium-atomic-artillery-wave"
     table.insert(projectiles, plutonium_atomic_artillery_projectile)
 
 

--- a/prototypes/entity/projectiles.lua
+++ b/prototypes/entity/projectiles.lua
@@ -48,7 +48,29 @@ plutonium_atomic_rocket.action.action_delivery.target_effects[18].action.radius 
 table.insert(projectiles, plutonium_atomic_rocket)
 
 
-if mods["AtomicArtillery"] then
+if mods['bobwarfare'] then
+    local plutonium_atomic_artillery_projectile = util.table.deepcopy(data.raw["artillery-projectile"]["atomic-artillery-projectile"])
+
+    plutonium_atomic_artillery_projectile.name = "plutonium-atomic-artillery-projectile"
+
+    plutonium_atomic_artillery_projectile.picture.filename = "__PlutoniumEnergy__/graphics/entity/plutonium-artillery-projectile/hr-plutonium-atomic-shell.png"
+    plutonium_atomic_artillery_projectile.chart_picture.filename = "__PlutoniumEnergy__/graphics/entity/plutonium-artillery-projectile/plutonium-atomic-artillery-shoot-map-visualization.png"
+
+    plutonium_atomic_artillery_projectile.action.action_delivery.target_effects[1].repeat_count = 140
+    plutonium_atomic_artillery_projectile.action.action_delivery.target_effects[3].damage.amount = 560
+    plutonium_atomic_artillery_projectile.action.action_delivery.target_effects[6].radius = 10
+    plutonium_atomic_artillery_projectile.action.action_delivery.target_effects[7].action.repeat_count = 2800
+    plutonium_atomic_artillery_projectile.action.action_delivery.target_effects[7].action.radius = 50
+    plutonium_atomic_artillery_projectile.action.action_delivery.target_effects[7].action.action_delivery.projectile = "plutonium-atomic-artillery-wave"
+    table.insert(projectiles, plutonium_atomic_artillery_projectile)
+
+
+    --[[local plutonium_atomic_artillery_wave = util.table.deepcopy(data.raw["projectile"]["atomic-artillery-wave"])
+    plutonium_atomic_artillery_wave.name = "plutonium-atomic-artillery-wave"
+    plutonium_atomic_artillery_wave.action[2].action_delivery.target_effects.damage.amount = 5600
+    table.insert(projectiles, plutonium_atomic_artillery_wave)]]
+
+elseif mods["AtomicArtillery"] then
     local plutonium_atomic_artillery_projectile = util.table.deepcopy(data.raw["artillery-projectile"]["atomic-artillery-projectile"])
 
     plutonium_atomic_artillery_projectile.name = "plutonium-atomic-artillery-projectile"
@@ -68,6 +90,7 @@ if mods["AtomicArtillery"] then
     plutonium_atomic_artillery_wave.name = "plutonium-atomic-artillery-wave"
     plutonium_atomic_artillery_wave.action[2].action_delivery.target_effects.damage.amount = 5600
     table.insert(projectiles, plutonium_atomic_artillery_wave)
+
 end
 
 data:extend(projectiles)

--- a/prototypes/item/ammo.lua
+++ b/prototypes/item/ammo.lua
@@ -1,4 +1,16 @@
-if mods["AtomicArtillery"] then
+if mods['bobwarfare'] then
+    local plutonium_atomic_artillery_shell = util.table.deepcopy(data.raw["ammo"]["atomic-artillery-shell"])
+
+    plutonium_atomic_artillery_shell.name = "plutonium-atomic-artillery-shell"
+    plutonium_atomic_artillery_shell.icon = "__PlutoniumEnergy__/graphics/icons/plutonium-atomic-artillery-shell.png"
+    plutonium_atomic_artillery_shell.icons = nil
+    plutonium_atomic_artillery_shell.icon_size = 64
+    plutonium_atomic_artillery_shell.icon_mipmaps = 4
+
+    plutonium_atomic_artillery_shell.projectile = "plutonium-atomic-artillery-projectile"
+    data:extend({plutonium_atomic_artillery_shell})
+
+elseif mods["AtomicArtillery"] then
     local plutonium_atomic_artillery_shell = util.table.deepcopy(data.raw["ammo"]["atomic-artillery-shell"])
 
     plutonium_atomic_artillery_shell.name = "plutonium-atomic-artillery-shell"
@@ -7,7 +19,6 @@ if mods["AtomicArtillery"] then
     plutonium_atomic_artillery_shell.icon_mipmaps = 4
 
     plutonium_atomic_artillery_shell.projectile = "plutonium-atomic-artillery-projectile"
-    plutonium_atomic_artillery_shell.ammo_type.action.action_delivery.starting_speed = 1.1
     data:extend({plutonium_atomic_artillery_shell})
 end
 

--- a/prototypes/recipe/ammo.lua
+++ b/prototypes/recipe/ammo.lua
@@ -9,7 +9,7 @@ if mods['bobwarfare'] then
         {"steel-plate", 8},
         {"plastic-bar", 8},
         {"explosives", 30},
-        {"plutonium-239", 30}
+        {"PE-plutonium-239", 30}
     }
     plutonium_atomic_artillery_shell.expensive.ingredients = {
         {"steel-plate", 16},

--- a/prototypes/recipe/ammo.lua
+++ b/prototypes/recipe/ammo.lua
@@ -5,9 +5,15 @@ if mods['bobwarfare'] then
 
     plutonium_atomic_artillery_shell.name = "plutonium-atomic-artillery-shell"
 
-    plutonium_atomic_artillery_shell.ingredients = {
+    plutonium_atomic_artillery_shell.normal.ingredients = {
         {"steel-plate", 8},
         {"plastic-bar", 8},
+        {"explosives", 30},
+        {"plutonium-239", 30}
+    }
+    plutonium_atomic_artillery_shell.expensive.ingredients = {
+        {"steel-plate", 16},
+        {"plastic-bar", 16},
         {"explosives", 30},
         {"plutonium-239", 30}
     }

--- a/prototypes/recipe/ammo.lua
+++ b/prototypes/recipe/ammo.lua
@@ -15,9 +15,10 @@ if mods['bobwarfare'] then
         {"steel-plate", 16},
         {"plastic-bar", 16},
         {"explosives", 30},
-        {"plutonium-239", 30}
+        {"PE-plutonium-239", 30}
     }
-    plutonium_atomic_artillery_shell.result = "plutonium-atomic-artillery-shell"
+    plutonium_atomic_artillery_shell.normal.result = "plutonium-atomic-artillery-shell"
+    plutonium_atomic_artillery_shell.normal.result = "plutonium-atomic-artillery-shell"
     table.insert(ammo_recipes, plutonium_atomic_artillery_shell)
 
 elseif mods["AtomicArtillery"] then

--- a/prototypes/recipe/ammo.lua
+++ b/prototypes/recipe/ammo.lua
@@ -1,6 +1,20 @@
 local ammo_recipes = {}
 
-if mods["AtomicArtillery"] then
+if mods['bobwarfare'] then
+    local plutonium_atomic_artillery_shell = util.table.deepcopy(data.raw["recipe"]["atomic-artillery-shell"])
+
+    plutonium_atomic_artillery_shell.name = "plutonium-atomic-artillery-shell"
+
+    plutonium_atomic_artillery_shell.ingredients = {
+        {"steel-plate", 8},
+        {"plastic-bar", 8},
+        {"explosives", 30},
+        {"plutonium-239", 30}
+    }
+    plutonium_atomic_artillery_shell.result = "plutonium-atomic-artillery-shell"
+    table.insert(ammo_recipes, plutonium_atomic_artillery_shell)
+
+elseif mods["AtomicArtillery"] then
     local plutonium_atomic_artillery_shell = util.table.deepcopy(data.raw["recipe"]["atomic-artillery-shell"])
 
     plutonium_atomic_artillery_shell.name = "plutonium-atomic-artillery-shell"
@@ -13,6 +27,7 @@ if mods["AtomicArtillery"] then
     }
     plutonium_atomic_artillery_shell.result = "plutonium-atomic-artillery-shell"
     table.insert(ammo_recipes, plutonium_atomic_artillery_shell)
+
 end
 
 if ammo_recipes[1] then data:extend(ammo_recipes) end

--- a/prototypes/recipe/ammo.lua
+++ b/prototypes/recipe/ammo.lua
@@ -18,7 +18,7 @@ if mods['bobwarfare'] then
         {"PE-plutonium-239", 30}
     }
     plutonium_atomic_artillery_shell.normal.result = "plutonium-atomic-artillery-shell"
-    plutonium_atomic_artillery_shell.normal.result = "plutonium-atomic-artillery-shell"
+    plutonium_atomic_artillery_shell.expensive.result = "plutonium-atomic-artillery-shell"
     table.insert(ammo_recipes, plutonium_atomic_artillery_shell)
 
 elseif mods["AtomicArtillery"] then

--- a/prototypes/recipe/ammo.lua
+++ b/prototypes/recipe/ammo.lua
@@ -58,10 +58,9 @@ data:extend({
         enabled = false,
         energy_required = 50,
         ingredients = {
-            {"processing-unit", 20},
+            {"rocket-control-unit", 10},
             {"explosives", 10},
-            {"PE-plutonium-238", 15},
-            {"PE-plutonium-239", 10}
+            {"PE-plutonium-239", 35}
         },
         result = "plutonium-atomic-bomb"
     },

--- a/prototypes/technology/ammo.lua
+++ b/prototypes/technology/ammo.lua
@@ -60,6 +60,8 @@ data:extend({
     }
 })
 
-if mods["AtomicArtillery"] then
+if mods['bobwarfare'] then
+    table.insert(data.raw['technology']['bob-atomic-artillery-shell'].effects, {type = 'unlock-recipe', recipe = 'plutonium-atomic-artillery-shell'})
+elseif mods["AtomicArtillery"] then
     table.insert(data.raw["technology"]["plutonium-ammo"].effects, {type = "unlock-recipe", recipe = "plutonium-atomic-artillery-shell"})
 end


### PR DESCRIPTION
```
Version: 1.1.20
Date: 26.08.2020
  Fixes:
    - Fixed error on load when Atomic Artillery, PE and Bob's Warfare are enabled
  Integration:
    - Plutonium Atomic Artillery shell is now available with Bob's Warfare mod.
  Balancing:
    - Plutonium atomic bomb:
      Removed processing unit from recipe
      Removed Pu-238 from recipe
      Pu-239 10x -> 35x
      Added x10 Rocket control unit
```