### PR TITLE
Address Deadlock989 suggestions

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -23,10 +23,6 @@ if mods['IndustrialRevolution3'] then
         end
     end
 
-    -- IR3 removes uranium-fuel, not a usable fuel for vehicles
-    data.raw['recipe']['plutonium-fuel'].hidden = true
-    data.raw['recipe']['plutonium-fuel'].enabled = false
-
     -- IR3 uses barreling machines
     data.raw['recipe']['advanced-nuclear-fuel-reprocessing-with-barrelling'].hidden = true
     data.raw['recipe']['advanced-nuclear-fuel-reprocessing-with-barrelling'].enabled = false

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -7,6 +7,9 @@ if mods['bobplates'] then
 end
 
 if mods['IndustrialRevolution3'] then
+    -- IR3 uses a barreling technology
+    data.raw['technology']['plutonium-processing'].prerequisites = { "uranium-processing", "nuclear-fuel-reprocessing", "ir-barrelling" }
+
     if data.raw['technology']['plutonium-ammo'] then
         data.raw['technology']['plutonium-ammo'].unit.count = 2000
         data.raw['technology']['plutonium-ammo'].unit.time = 60

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -46,32 +46,32 @@ if mods['IndustrialRevolution3'] then
         end
     end
 
-    -- assign IR3 subgroups
-    data.raw['recipe']['MOX-reactor'].subgroup = "ir-nuclear-machines"
-    data.raw['recipe']['MOX-reactor'].order = "f[nuclear-energy]-a[reactor]"
-
+    -- assign IR3 subgroups to items
     data.raw['item']['MOX-reactor'].subgroup = "ir-nuclear-machines"
-    data.raw['item']['MOX-reactor'].order = "f[nuclear-energy]-a[reactor]"
-
-    data.raw['recipe']['breeder-reactor'].subgroup = "ir-nuclear-machines"
-    data.raw['recipe']['breeder-reactor'].order = "f[nuclear-energy]-a[reactor]"
+    data.raw['item']['MOX-reactor'].order = "f[nuclear-energy]-a[mox-reactor]"
 
     data.raw['item']['breeder-reactor'].subgroup = "ir-nuclear-machines"
-    data.raw['item']['breeder-reactor'].order = "f[nuclear-energy]-a[reactor]"
+    data.raw['item']['breeder-reactor'].order = "f[nuclear-energy]-a[breeder-reactor]"
 
-    -- data.raw['recipe']['MOX-fuel'].subgroup is assigned in recipes.lua
-    data.raw['recipe']['MOX-fuel'].order = "r[uranium-processing]-e[MOX-fuel-processing]"
+    data.raw['item']['MOX-fuel'].subgroup = "ir-fuels"
+    data.raw['item']['MOX-fuel'].order = "zz[mox-fuel]"
 
-    data.raw['item']['MOX-fuel'].subgroup = "intermediate-product"
-    data.raw['item']['MOX-fuel'].order = "r[uranium-processing]-e[MOX-fuel-processing]"
+    data.raw['item']['used-up-MOX-fuel'].subgroup = "ir-fuels"
+    data.raw['item']['used-up-MOX-fuel'].order = "zz[mox-fuel-used]"
 
-    data.raw['item']['used-up-MOX-fuel'].subgroup = "intermediate-product"
-    data.raw['item']['used-up-MOX-fuel'].order = 'r[used-up-uranium-fuel-cell]-b'
+    data.raw['item']['breeder-fuel-cell'].subgroup = "ir-fuels"
+    data.raw['item']['breeder-fuel-cell'].order = "zz[breeder-fuel-cell]"
+
+    data.raw['item']['used-up-breeder-fuel-cell'].subgroup = "ir-fuels"
+    data.raw['item']['used-up-breeder-fuel-cell'].order = "zz[breeder-fuel-cell-used]"
+
+    data.raw['item']['plutonium-238'].subgroup = "ir-fuels"
+    data.raw['item']['plutonium-238'].order = "cc[plutonium-238]"
+
+    data.raw['item']['plutonium-239'].subgroup = "ir-fuels"
+    data.raw['item']['plutonium-239'].order = "cc[plutonium-239]"
 
     if settings.startup['enable-plutonium-ammo'].value then
-        data.raw['recipe']['plutonium-rounds-magazine'].subgroup = 'ir-ammo'
-        data.raw['recipe']['plutonium-rounds-magazine'].order = 'c-q'
-
         data.raw['ammo']['plutonium-rounds-magazine'].subgroup = 'ir-ammo'
         data.raw['ammo']['plutonium-rounds-magazine'].order = 'c-q'
     end

--- a/prototypes/recipe/recipes.lua
+++ b/prototypes/recipe/recipes.lua
@@ -384,6 +384,21 @@ if mods["IndustrialRevolution3"] then
         { "refined-concrete",   500 }
     }
 
+    data.raw['recipe']['MOX-reactor'].subgroup = "ir-nuclear-machines"
+    data.raw['recipe']['MOX-reactor'].order = "f[nuclear-energy]-a[mox-reactor]"
+
+    data.raw['recipe']['breeder-reactor'].subgroup = "ir-nuclear-machines"
+    data.raw['recipe']['breeder-reactor'].order = "f[nuclear-energy]-a[breeder-reactor]"
+
+    if settings.startup['enable-plutonium-ammo'].value then
+        data.raw['recipe']['plutonium-rounds-magazine'].subgroup = 'ir-ammo'
+        data.raw['recipe']['plutonium-rounds-magazine'].order = 'c-q'
+    end
+
+    -- IR3 removes uranium-fuel, not a usable fuel for vehicles
+    data.raw['recipe']['plutonium-fuel'].hidden = true
+    data.raw['recipe']['plutonium-fuel'].enabled = false
+
     -- Add steel, lead, and concrete scrap to reprocessing recipes
     table.insert(data.raw['recipe']['MOX-fuel-reprocessing'].results, { name = "steel-scrap", amount_max = 3, amount_min = 1 })
     table.insert(data.raw['recipe']['MOX-fuel-reprocessing'].results, { name = "lead-scrap", amount_max = 2, amount_min = 1 })
@@ -397,14 +412,13 @@ if mods["IndustrialRevolution3"] then
     table.insert(data.raw['recipe']['advanced-nuclear-fuel-reprocessing'].results, { name = "lead-scrap", amount_max = 2, amount_min = 1 })
     table.insert(data.raw['recipe']['advanced-nuclear-fuel-reprocessing'].results, { name = "concrete-scrap", amount_max = 2, amount_min = 1 })
 
-    -- new subgroup, IR3 has many 'intermediate-products'
+    -- new subgroup, after uranium recipes
     data:extend({ {
         type = 'item-subgroup',
         name = 'pe',
-        group = 'intermediate-products',
-        order = 'gz',
+        group = 'ir-processing',
+        order = 'zzzz',
     } })
-
     data.raw['recipe']['MOX-fuel'].subgroup = 'pe'
     data.raw['recipe']['breeder-fuel-cell'].subgroup = 'pe'
     data.raw['recipe']['MOX-fuel-reprocessing'].subgroup = 'pe'

--- a/prototypes/recipe/recipes.lua
+++ b/prototypes/recipe/recipes.lua
@@ -384,15 +384,18 @@ if mods["IndustrialRevolution3"] then
         { "refined-concrete",   500 }
     }
 
-    -- Add steel and lead scrap to reprocessing recipes
-    table.insert(data.raw['recipe']['MOX-fuel-reprocessing'].results, { name = "steel-scrap", amount = 4 })
-    table.insert(data.raw['recipe']['MOX-fuel-reprocessing'].results, { name = "lead-scrap", amount = 2 })
+    -- Add steel, lead, and concrete scrap to reprocessing recipes
+    table.insert(data.raw['recipe']['MOX-fuel-reprocessing'].results, { name = "steel-scrap", amount_max = 3, amount_min = 1 })
+    table.insert(data.raw['recipe']['MOX-fuel-reprocessing'].results, { name = "lead-scrap", amount_max = 2, amount_min = 1 })
+    table.insert(data.raw['recipe']['MOX-fuel-reprocessing'].results, { name = "concrete-scrap", amount_max = 2, amount_min = 1 })
 
-    table.insert(data.raw['recipe']['breeder-fuel-cell-reprocessing'].results, { name = "steel-scrap", amount = 4 })
-    table.insert(data.raw['recipe']['breeder-fuel-cell-reprocessing'].results, { name = "lead-scrap", amount = 2 })
+    table.insert(data.raw['recipe']['breeder-fuel-cell-reprocessing'].results, { name = "steel-scrap", amount_max = 3, amount_min = 1 })
+    table.insert(data.raw['recipe']['breeder-fuel-cell-reprocessing'].results, { name = "lead-scrap", amount_max = 2, amount_min = 1 })
+    table.insert(data.raw['recipe']['breeder-fuel-cell-reprocessing'].results, { name = "concrete-scrap", amount_max = 2, amount_min = 1 })
 
-    table.insert(data.raw['recipe']['advanced-nuclear-fuel-reprocessing'].results, { name = "steel-scrap", amount = 4 })
-    table.insert(data.raw['recipe']['advanced-nuclear-fuel-reprocessing'].results, { name = "lead-scrap", amount = 2 })
+    table.insert(data.raw['recipe']['advanced-nuclear-fuel-reprocessing'].results, { name = "steel-scrap", amount_max = 3, amount_min = 1 })
+    table.insert(data.raw['recipe']['advanced-nuclear-fuel-reprocessing'].results, { name = "lead-scrap", amount_max = 2, amount_min = 1 })
+    table.insert(data.raw['recipe']['advanced-nuclear-fuel-reprocessing'].results, { name = "concrete-scrap", amount_max = 2, amount_min = 1 })
 
     -- new subgroup, IR3 has many 'intermediate-products'
     data:extend({ {
@@ -410,4 +413,5 @@ if mods["IndustrialRevolution3"] then
     data.raw['recipe']['breeder-fuel-cell-from-MOX-fuel'].subgroup = 'pe'
     data.raw['recipe']['breeder-fuel-cell-from-uranium-cell'].subgroup = 'pe'
     data.raw['recipe']['used-up-uranium-fuel-cell-solution-centrifuging'].subgroup = 'pe'
+    data.raw['recipe']['used-up-breeder-fuel-cell-solution-centrifuging'].subgroup = 'pe'
 end

--- a/prototypes/recipe/recipes.lua
+++ b/prototypes/recipe/recipes.lua
@@ -404,9 +404,9 @@ if mods["IndustrialRevolution3"] then
     table.insert(data.raw['recipe']['MOX-fuel-reprocessing'].results, { name = "lead-scrap", amount_max = 2, amount_min = 1 })
     table.insert(data.raw['recipe']['MOX-fuel-reprocessing'].results, { name = "concrete-scrap", amount_max = 2, amount_min = 1 })
 
-    table.insert(data.raw['recipe']['breeder-fuel-cell-reprocessing'].results, { name = "steel-scrap", amount_max = 3, amount_min = 1 })
-    table.insert(data.raw['recipe']['breeder-fuel-cell-reprocessing'].results, { name = "lead-scrap", amount_max = 2, amount_min = 1 })
-    table.insert(data.raw['recipe']['breeder-fuel-cell-reprocessing'].results, { name = "concrete-scrap", amount_max = 2, amount_min = 1 })
+    table.insert(data.raw['recipe']['breeder-fuel-cell-reprocessing'].results, { name = "steel-scrap", amount_max = 6, amount_min = 3 })
+    table.insert(data.raw['recipe']['breeder-fuel-cell-reprocessing'].results, { name = "lead-scrap", amount_max = 4, amount_min = 2 })
+    table.insert(data.raw['recipe']['breeder-fuel-cell-reprocessing'].results, { name = "concrete-scrap", amount_max = 4, amount_min = 2 })
 
     table.insert(data.raw['recipe']['advanced-nuclear-fuel-reprocessing'].results, { name = "steel-scrap", amount_max = 3, amount_min = 1 })
     table.insert(data.raw['recipe']['advanced-nuclear-fuel-reprocessing'].results, { name = "lead-scrap", amount_max = 2, amount_min = 1 })


### PR DESCRIPTION
This is to address the points 1 & 3 in issue #92.
Plutonium processing technology prerequisite changed from vanilla fluid-handling to ir-barrelling.
Adjusted reprocessing recipes, lower steel scrap by 1 and added concrete scrap and variable product amounts to be more IR3-like.

Point 2, this is your choice. I did move PE recipes to a single row. But as for the tab, I left them as you placed them.
Separates PE recipes from vanilla as more advanced process/products. But I can see the point of having all nuclear in one place.

Point 4, I do not use FNEI but rather RecipeBook. If I change the settings to include disabled and hidden recipes they are visible. I think the recipes would need to be set to nil to remove completely, but not sure.