### PR TITLE
Update data-updates.lua

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -93,6 +93,15 @@ if mods['SchallRadioactiveWaste'] then
     ]]
 end
 
+if mods['SchallRadioactiveWaste'] then
+	data.raw["recipe"]["MOX-fuel"].ingredients = {
+		{ "iron-plate",				10 },
+		{ "uranium-low-enriched",	1 },
+		{ "plutonium-239",			3 },
+		{ "plutonium-238",			15 }
+	}
+end
+
 -- check for tech prerequisites
 
 if not data.raw['technology']['kovarex-enrivhment-process'] then

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -93,7 +93,7 @@ if mods['SchallRadioactiveWaste'] then
     ]]
 end
 
-if mods['SchallRadioactiveWaste'] then
+if mods['SchallUraniumProcessing'] then
 	data.raw["recipe"]["MOX-fuel"].ingredients = {
 		{ "iron-plate",				10 },
 		{ "uranium-low-enriched",	1 },


### PR DESCRIPTION
Minor tweak to add specialized compatibility with Schall Uranium Processing. MOX Fuel in real life only requires low-enriched uranium, which Schall Uranium Processing adds. The MOX Fuel recipe is tweaked to require low-enriched uranium instead of highly-enriched uranium, which is what U-235 becomes when Schall Uranium Processing is active. The recipe quantities remain unchanged.